### PR TITLE
Check for existing Mint GRUB snippet before using default GRUB

### DIFF
--- a/usr/lib/linuxmint/mintsysadm/mintsysadm.py
+++ b/usr/lib/linuxmint/mintsysadm/mintsysadm.py
@@ -20,6 +20,7 @@ setproctitle.setproctitle("mintsysadm")
 _ = xapp.util.l10n("mintsysadm")
 
 GRUB_FILE = "/etc/default/grub.d/98_mintsysadm.cfg"
+DEFAULT_GRUB_FILE = "/etc/default/grub"
 
 class MyApplication(Gtk.Application):
     # Main initialization routine
@@ -143,8 +144,17 @@ class MintSysadmWindow():
             self.builder.get_object("grub_timeout_spinner").get_adjustment().set_lower(0.0)
         self.builder.get_object("grub_timeout_spinner").update()
 
+    def get_existing_grub_path(self):
+        # Return the Mint-relevant GRUB file to use.
+        # Checks mintsysadm first, then falls back to default grub.
+        for path in [GRUB_FILE, DEFAULT_GRUB_FILE]:
+            if os.path.exists(path):
+                return path
+        return None
+
     def get_boot_config(self):
-        if not os.path.exists(GRUB_FILE):
+        file_to_read = self.get_existing_grub_path()
+        if not file_to_read:
             return
         menu_visible = False
         menu_timeout = 0
@@ -153,7 +163,7 @@ class MintSysadmWindow():
         # but since we're making this file we can assume if one is here the other is.
         savedefault_present = False
         boot_args = []
-        with open(GRUB_FILE, "r") as grub_file:
+        with open(file_to_read, "r") as grub_file:
             for line in grub_file:
                 line = line.strip()
                 if "GRUB_TIMEOUT=" in line:


### PR DESCRIPTION
### Summary
Ensure the Boot Menu page correctly reflects existing GRUB settings
by preferring the Mint‑managed snippet `/etc/default/grub.d/98_mintsysadm.cfg`
and only falling back to `/etc/default/grub` when the snippet doesn’t exist.

### Motivation
On systems upgraded from older Mint releases, the default `/etc/default/grub`
file contains valid GRUB settings, but the tool did not display them
because it only looked for the Mint snippet. This change improves UX
by making the Boot menu page reflect actual GRUB configuration.

### Implementation
- Add `get_existing_grub_path()` helper to choose the correct file.
- Update `get_boot_config()` to use this choice.
- No change to writing logic — only reading fallback behavior.